### PR TITLE
Fix: Float to int gives an incorrect value.

### DIFF
--- a/src/Currency.php
+++ b/src/Currency.php
@@ -58,6 +58,6 @@ class Currency implements CastsAttributes
      */
     public function set($model, string $key, $value, array $attributes)
     {
-        return (int) ($value * (10 ** $this->digits));
+        return (int) round(($value * (10 ** $this->digits)), 0);
     }
 }


### PR DESCRIPTION
>>> (int) (290.15 * 100);
=> 29014
>>> (int) round((290.15 * 100), 0);
=> 29015

If you try to do var_dump(290.15*100) you can see that the internal representation is float(29014.999999999996). So applying (int) takes the integer part, that is 29014, while using round() takes the closer integer value.